### PR TITLE
cloneDate for rangeStart / rangeEnd

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -1,4 +1,3 @@
-
 fc.sourceNormalizers = [];
 fc.sourceFetchers = [];
 
@@ -58,8 +57,8 @@ function EventManager(options, _sources) {
 	
 	
 	function fetchEvents(start, end) {
-		rangeStart = start;
-		rangeEnd = end;
+		rangeStart = cloneDate(start);
+		rangeEnd = cloneDate(end);
 		cache = [];
 		var fetchID = ++currentFetchID;
 		var len = sources.length;

--- a/src/resource/ResourceView.js
+++ b/src/resource/ResourceView.js
@@ -1,4 +1,3 @@
-
 setDefaults({
 	weekMode: 'fixed',
 	titleFormat: {
@@ -420,8 +419,7 @@ function ResourceView(element, calendar, viewName) {
 	
 	function dayClick(ev) {
 		if (!opt('selectable')) { // if selectable, SelectionManager will worry about dayClick
-			var index = parseInt(this.className.match(/fc\-day(\d+)/)[1]); // TODO: maybe use .data
-			var date = indexDate(index);
+			var date = new Date(Date.parse($(this).data("date")));
 			trigger('dayClick', this, date, true, ev);
 		}
 	}


### PR DESCRIPTION
"start" and "end" should be cloned. Causes unintended change of "rangeStart" (and "rangeEnd"), thereby not fetching events in the first time when clicking "prev"
