### PR TITLE
Simplified getting column index

### DIFF
--- a/src/resource/ResourceView.js
+++ b/src/resource/ResourceView.js
@@ -763,31 +763,9 @@ function ResourceView(element, calendar, viewName) {
 	}
 	
 	function timeOfDayCol(datetime) {
-		var hours = datetime.getHours();
-		var minutes = datetime.getMinutes();
-		var slotMinutes = opt('slotMinutes');
-		var slot, diff, minDiff, closestMinute;
-		
-		// round minutes to closest minuteslot
-		for ( var i = 0 ; i <= 60/slotMinutes; i++) {
-			slot = i*slotMinutes;
-
-			diff = Math.abs(slot-minutes);
-			
-			if (diff <= minDiff || i == 0) {
-				minDiff = diff;
-				closestMinute = slot;
-			}
-			
-			if(closestMinute == 60) {
-				hours++;
-				closestMinute = 0;
-			}
-		}		
-		minutes = closestMinute;
-
-		for ( var i = 0; i < colCnt; i++) {
-			if (indexDate(i).getHours() == hours && indexDate(i).getMinutes() == minutes) {
+	    	// find column index
+		for ( var i = 0; i < colCnt - 1; i++) {
+			if (datetime >= indexDate(i) && datetime < indexDate(i + 1)) {
 				return i;
 			}
 		}


### PR DESCRIPTION
The previous method returned colCnt (max) when using slotMinutes: 50. This simplified method should always return the correct slot.
