### PR TITLE
Fix for resize after dragging external event

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,3 @@
-
 fc.applyAll = applyAll;
 
 
@@ -33,6 +32,7 @@ function lazySegBind(container, segs, bindHandlers) {
 			i, seg;
 		while (parent != this) {
 			e = parent;
+			if (!parent.parentNode) break;
 			parent = parent.parentNode;
 		}
 		if ((i = e._fci) !== undefined) {


### PR DESCRIPTION
After dragging an event in the calendar, this method throws an exception when resizing the event.
