### PR TITLE
init date not working

### DIFF
--- a/src/resource/ResourceDayView.js
+++ b/src/resource/ResourceDayView.js
@@ -1,4 +1,3 @@
-
 fcViews.resourceDay = ResourceDayView;
 
 function ResourceDayView(element, calendar) {
@@ -21,9 +20,6 @@ function ResourceDayView(element, calendar) {
 		if (delta) {
 			addDays(date, delta * 1);
 			if (!opt('weekends')) skipWeekend(date, delta < 0 ? -1 : 1);
-		}
-		else {
-			date = new Date();
 		}
 
 		var start = addMinutes(cloneDate(date, true),parseTime(opt('minTime')));


### PR DESCRIPTION
why here is created a new Data object ?
if is new object of Data you can't init calendar with other date than today. Options: year, month, date are not working and are irrelevant, same in ResourceWeekView and ResourceNextWeeksView (ResourceMonthView works fine).
