### PR TITLE
Fixed Bug in $.fullCalendar('unselect') and reportSelection in ResourceView when selectable option is true and when date, month, year is specified for default date

### DIFF
--- a/src/common/SelectionManager.js
+++ b/src/common/SelectionManager.js
@@ -39,13 +39,13 @@ function SelectionManager() {
 	}
 	
 
-	function select(startDate, endDate, allDay) {
+	function select(startDate, endDate, allDay, ev, view, resource) {
 		unselect();
 		if (!endDate) {
 			endDate = defaultSelectionEnd(startDate, allDay);
 		}
 		renderSelection(startDate, endDate, allDay);
-		reportSelection(startDate, endDate, allDay);
+		reportSelection(startDate, endDate, allDay, ev, view, resource);
 	}
 	
 	
@@ -58,9 +58,9 @@ function SelectionManager() {
 	}
 	
 	
-	function reportSelection(startDate, endDate, allDay, ev) {
+	function reportSelection(startDate, endDate, allDay, ev, view, resource) {
 		selected = true;
-		trigger('select', null, startDate, endDate, allDay, ev);
+		trigger('select', null, startDate, endDate, allDay, ev, view, resource);
 	}
 	
 	

--- a/src/resource/ResourceDayView.js
+++ b/src/resource/ResourceDayView.js
@@ -23,7 +23,7 @@ function ResourceDayView(element, calendar) {
 			if (!opt('weekends')) skipWeekend(date, delta < 0 ? -1 : 1);
 		}
 		else {
-			date = new Date();
+			date = date || new Date();
 		}
 
 		var start = addMinutes(cloneDate(date, true),parseTime(opt('minTime')));

--- a/src/resource/ResourceNextWeeksView.js
+++ b/src/resource/ResourceNextWeeksView.js
@@ -35,7 +35,7 @@ function ResourceNextWeeksView(element, calendar) {
 			var end = addDays(cloneDate(start), opt('numberOfWeeks') * 7);
 		}
 		else {
-			date = new Date();
+			date = date || new Date();
 			var start = addDays(cloneDate(date), -((date.getDay() - opt('firstDay') + weekDays) % weekDays), false);
 			var end = addDays(cloneDate(start), opt('numberOfWeeks')*7);
 		}

--- a/src/resource/ResourceView.js
+++ b/src/resource/ResourceView.js
@@ -857,7 +857,7 @@ function ResourceView(element, calendar, viewName) {
 					if (+dates[0] == +dates[1]) {
 						reportDayClick(dates[0],(viewName == 'resourceDay' ? false : true), ev, resources[row]);
 					}
-					reportSelection(dates[0], (viewName == 'resourceDay' ? addMinutes(dates[1], opt('slotMinutes')) : dates[1]), (viewName == 'resourceDay' ? false : true), ev, resources[row]);
+					reportSelection(dates[0], (viewName == 'resourceDay' ? addMinutes(dates[1], opt('slotMinutes')) : dates[1]), (viewName == 'resourceDay' ? false : true), ev, t, resources[row]);
 				}
 			});
 		}

--- a/src/resource/ResourceView.js
+++ b/src/resource/ResourceView.js
@@ -84,6 +84,7 @@ function ResourceView(element, calendar, viewName) {
 	var clearOverlays = t.clearOverlays;
 	var formatDate = calendar.formatDate;
 	var getResources = t.getResources;
+	var reportSelection = t.reportSelection; //Revert back to SelectionManager's reportSelection
 
 	// locals
 	var table;
@@ -808,15 +809,6 @@ function ResourceView(element, calendar, viewName) {
 			left: $(head).find('th.fc-resourceName').width(),
 			right: $(head).width()
 		};
-	}
-
-	function reportSelection(startDate, endDate, allDay, ev, resource) {
-		if (typeof resource == 'object' && resource.readonly === true) {
-			return false;
-		}
-
-		selected = true;
-		trigger('select', null, startDate, endDate, allDay, ev, '', resource);
 	}
 
 	function isResourceEditable(resourceId) {

--- a/src/resource/ResourceView.js
+++ b/src/resource/ResourceView.js
@@ -857,7 +857,7 @@ function ResourceView(element, calendar, viewName) {
 					if (+dates[0] == +dates[1]) {
 						reportDayClick(dates[0],(viewName == 'resourceDay' ? false : true), ev, resources[row]);
 					}
-					reportSelection(dates[0], (viewName == 'resourceDay' ? addMinutes(dates[1], opt('slotMinutes')) : dates[1]), (viewName == 'resourceDay' ? false : true), ev, t, resources[row]);
+					reportSelection(dates[0], (viewName == 'resourceDay' ? addMinutes(dates[1], opt('slotMinutes')) : dates[1]), (viewName == 'resourceDay' ? false : true), ev, t, resources[row]); //Added the CurrentView (t) to reportSelection Call
 				}
 			});
 		}

--- a/src/resource/ResourceView.js
+++ b/src/resource/ResourceView.js
@@ -192,7 +192,7 @@ function ResourceView(element, calendar, viewName) {
 
 		// trigger resourceRender callback now when the skeleton is ready
 		body.find('td.fc-resourceName').each(function(i, resourceElement) {
-			trigger('resourceRender', resources[i], resourceElement, viewName);
+			trigger('resourceRender', resources[i], resources[i], resourceElement);
 		});
 
 		firstRowCellInners = bodyRows.eq(0).find('.fc-day > div');

--- a/src/resource/ResourceWeekView.js
+++ b/src/resource/ResourceWeekView.js
@@ -27,7 +27,7 @@ function ResourceWeekView(element, calendar) {
 			var end = addDays(cloneDate(start), 7);
 		}
 		else {
-			date = new Date();
+			date = date || new Date();
 			var start = addDays(cloneDate(date, true), -((date.getDay() - opt('firstDay') + 7) % 7));
 			var end = addDays(cloneDate(start), 7);
 		}


### PR DESCRIPTION
When in any of the resourceviews with selectable option of $.fullCalendar({}) is set to true, the overlay was not removed.

-- Added "ev, view, resource" arguments to SelectionManager's select and reportSelection functions
-- Removed reportSelection function from ResourceView and revert back to S
-- Added the CurrentView (t) to reportSelection Call
-- Fixed bugs when default date is specified using date, month and year options
